### PR TITLE
Consider step prio in syntax highlighting

### DIFF
--- a/src/org/technbolts/jbehave/eclipse/editors/story/MarkingStoryValidator.java
+++ b/src/org/technbolts/jbehave/eclipse/editors/story/MarkingStoryValidator.java
@@ -20,8 +20,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.technbolts.eclipse.util.MarkData;
 import org.technbolts.jbehave.eclipse.Activator;
-import org.technbolts.jbehave.eclipse.JBehaveProject;
 import org.technbolts.jbehave.eclipse.PotentialStep;
+import org.technbolts.jbehave.eclipse.util.PotentialStepPrioTransformer;
 import org.technbolts.jbehave.eclipse.util.StepLocator;
 import org.technbolts.jbehave.eclipse.util.StoryPartDocumentUtils;
 import org.technbolts.jbehave.parser.Constants;
@@ -258,18 +258,6 @@ public class MarkingStoryValidator {
                     Marks.putStepsAsHtml(mark, candidates);
                     log.debug("#{} matching steps but only one with the highest priority for {}", candidates.size(), key);
                 }
-            }
-        }
-    }
-
-    static final class PotentialStepPrioTransformer extends F<PotentialStep,Integer> {
-        @Override
-        public Integer f(PotentialStep pStep) {
-            try {
-                Integer prioValue = JBehaveProject.getValue(pStep.annotation.getMemberValuePairs(), "priority");
-                return prioValue == null ? Integer.valueOf(0) : prioValue;
-            } catch (JavaModelException e) {
-                return Integer.valueOf(0);
             }
         }
     }

--- a/src/org/technbolts/jbehave/eclipse/editors/story/Marks.java
+++ b/src/org/technbolts/jbehave/eclipse/editors/story/Marks.java
@@ -12,6 +12,7 @@ import org.technbolts.jbehave.eclipse.PotentialStep;
 public class Marks {
     public static final String ERROR_CODE = "errorCode";
     public static final String STEPS_HTML = "stepsHtml";
+    public static final String MESSAGE = "message";
 
     public enum Code {
         Unknown(-1),

--- a/src/org/technbolts/jbehave/eclipse/editors/story/StoryAnnotationHover.java
+++ b/src/org/technbolts/jbehave/eclipse/editors/story/StoryAnnotationHover.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import org.apache.commons.lang.StringEscapeUtils;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.ui.PreferenceConstants;
@@ -148,7 +149,12 @@ public class StoryAnnotationHover implements IAnnotationHover, IAnnotationHoverE
                     case MultipleMatchingSteps:
                     case MultipleMatchingSteps_PrioritySelection: {
                         String html = (String)marker.getAttribute(Marks.STEPS_HTML);
-                        return "<b>Multiple step matching:</b><br><br>"+html;
+                        String message = (String) marker.getAttribute(Marks.MESSAGE);
+                        if (message == null) {
+                            message = "<b>Multiple steps matching:</b>";
+                        }
+                        message = StringEscapeUtils.escapeHtml(message);
+                        return String.format("%s<br><br>%s", message, html);
                     }
                 }
             }

--- a/src/org/technbolts/jbehave/eclipse/util/PotentialStepPrioFilter.java
+++ b/src/org/technbolts/jbehave/eclipse/util/PotentialStepPrioFilter.java
@@ -1,0 +1,26 @@
+package org.technbolts.jbehave.eclipse.util;
+
+import org.eclipse.jdt.core.JavaModelException;
+import org.technbolts.jbehave.eclipse.JBehaveProject;
+import org.technbolts.jbehave.eclipse.PotentialStep;
+
+import fj.F;
+
+final class PotentialStepPrioFilter extends F<PotentialStep, Boolean> {
+    private final int maxPrio;
+
+    PotentialStepPrioFilter(int maxPrio) {
+        this.maxPrio = maxPrio;
+    }
+
+    @Override
+    public Boolean f(PotentialStep pStep) {
+        try {
+            Integer prioValue = JBehaveProject.getValue(pStep.annotation.getMemberValuePairs(), "priority");
+            prioValue = prioValue == null ? 0 : prioValue;
+            return maxPrio == prioValue;
+        } catch (JavaModelException e) {
+            return maxPrio == 0;
+        }
+    }
+}

--- a/src/org/technbolts/jbehave/eclipse/util/PotentialStepPrioTransformer.java
+++ b/src/org/technbolts/jbehave/eclipse/util/PotentialStepPrioTransformer.java
@@ -1,0 +1,20 @@
+package org.technbolts.jbehave.eclipse.util;
+
+import org.eclipse.jdt.core.JavaModelException;
+import org.technbolts.jbehave.eclipse.JBehaveProject;
+import org.technbolts.jbehave.eclipse.PotentialStep;
+
+import fj.F;
+
+public final class PotentialStepPrioTransformer extends F<PotentialStep, Integer> {
+
+    @Override
+    public Integer f(PotentialStep pStep) {
+        try {
+            Integer prioValue = JBehaveProject.getValue(pStep.annotation.getMemberValuePairs(), "priority");
+            return prioValue == null ? Integer.valueOf(0) : prioValue;
+        } catch (JavaModelException e) {
+            return Integer.valueOf(0);
+        }
+    }
+}

--- a/src/org/technbolts/jbehave/eclipse/util/StepLocator.java
+++ b/src/org/technbolts/jbehave/eclipse/util/StepLocator.java
@@ -11,6 +11,9 @@ import org.technbolts.jbehave.eclipse.PotentialStep;
 import org.technbolts.util.HasHTMLComment;
 import org.technbolts.util.Visitor;
 
+import fj.Ord;
+import static fj.data.List.iterableList;
+
 public class StepLocator {
     
     public interface Provider {
@@ -101,7 +104,7 @@ public class StepLocator {
     }
     
     /**
-     * Returns the first {@link PotentialStep} found that match the step.
+     * Returns the first {@link PotentialStep} found that match the step, ordered by priority.
      * Be careful that there can be several other {@link PotentialStep}s that fulfill the step too.
      * 
      * @param step
@@ -109,22 +112,38 @@ public class StepLocator {
      */
     public PotentialStep findFirstStep(final String step) {
         try {
-            Visitor<PotentialStep, PotentialStep> findOne = new Visitor<PotentialStep, PotentialStep>() {
+            Visitor<PotentialStep, PotentialStep> matchingStepVisitor = new Visitor<PotentialStep, PotentialStep>() {
                 @Override
                 public void visit(PotentialStep candidate) {
                     boolean matches = candidate.matches(step);
                     if(matches) {
                         add(candidate);
-                        done();
                     }
                 }
             };
-            traverseSteps(findOne);
-            return findOne.getFirst();
+            traverseSteps(matchingStepVisitor);
+            return getFirstStepWithHighestPrio(matchingStepVisitor.getFounds());
         } catch (JavaModelException e) {
             Activator.logError("Failed to find candidates for step <" + step + ">", e);
         }
         return null;
+    }
+
+    /**
+     * 
+     * @param findOne
+     * @return
+     */
+    PotentialStep getFirstStepWithHighestPrio(Iterable<PotentialStep> potentialSteps) {
+        fj.data.List<Integer> collectedPrios = iterableList(potentialSteps).map(new PotentialStepPrioTransformer());
+        if (collectedPrios.isEmpty()) {
+            return null;
+        }
+        
+        final int maxPrio = collectedPrios.maximum(Ord.intOrd);
+        fj.data.List<PotentialStep> maxPrioSteps = iterableList(potentialSteps).filter(new PotentialStepPrioFilter(maxPrio));
+        
+        return maxPrioSteps.head();
     }
     
     public IJavaElement findMethod(final String step) {


### PR DESCRIPTION
I added support for priorities in the editor syntax highlighting and carried over the message from the info marker in the Problems view to the information hover.

This will take care of the correct part of the line being highlighted as parameter values for the highest priority matching step. When there are multiple steps with the same (elevated) prio, semantics are the same as they are now (first match wins).
